### PR TITLE
Fix/windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
 node_js:
+  - "0.11"
   - "0.10"
-  - "0.8"
+before_install: npm install -g grunt-cli
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ node_js:
 before_install: npm install -g grunt-cli
 notifications:
   email: false
+os:
+  - linux
+  - osx

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,30 @@
+module.exports = function(grunt) {
+  grunt.initConfig({
+    mochaTest: {
+      test: {
+        options: {
+          reporter: "spec",
+        },
+        src: ["test/**/*.js"]
+      }
+    },
+    jshint: {
+      all: [
+        'index.js'
+      ],
+      options: {
+        asi: true,
+      }
+    },
+    watch: {
+      files: ["Gruntfile.js", "test/**/*.js"],
+      tasks: ['test', 'jslint']
+    }
+  });
+  grunt.event.on("watch", function(action, filepath, target) {
+    grunt.log.writeln(target + ": " + filepath + " has " + action);
+  });
+  require("matchdep").filterDev("grunt-*").forEach(grunt.loadNpmTasks);
+  grunt.registerTask("test", ['mochaTest']);
+  grunt.registerTask("default", ['jshint', 'test']);
+};

--- a/index.js
+++ b/index.js
@@ -129,7 +129,6 @@ function run(baseDir, privKey, cmd, keyMode, cb) {
         if (typeof(emitter) === 'object') {
           emitter.emit('stdout', buf)
         }
-        console.log(buf)
         proc.stdoutBuffer += buf
       })
 
@@ -137,7 +136,6 @@ function run(baseDir, privKey, cmd, keyMode, cb) {
         if (typeof(emitter) === 'object') {
           emitter.emit('stderr', buf)
         }
-        console.log(buf)
         proc.stderrBuffer += buf
       })
 

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function writeFiles(privKey, file, keyMode, cb) {
 // spawned process should be detached from this one, and defaults to true.
 // Detachment means the git process won't hang trying to prompt for a password.
 function run(baseDir, privKey, cmd, keyMode, cb) {
-  var detached = true
+  var detached = isWindows ? false : true
   var spawnFn = spawn
   if (typeof(keyMode) === 'function') {
     cb = keyMode
@@ -129,6 +129,7 @@ function run(baseDir, privKey, cmd, keyMode, cb) {
         if (typeof(emitter) === 'object') {
           emitter.emit('stdout', buf)
         }
+        console.log(buf)
         proc.stdoutBuffer += buf
       })
 
@@ -136,6 +137,7 @@ function run(baseDir, privKey, cmd, keyMode, cb) {
         if (typeof(emitter) === 'object') {
           emitter.emit('stderr', buf)
         }
+        console.log(buf)
         proc.stderrBuffer += buf
       })
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var emitter
 
 // Template string for wrapper script.
 var GIT_SSH_TEMPLATE = '#!/bin/sh\n' +
-'exec ssh -i $key -o StrictHostKeyChecking=no "$@"\n'
+'ssh -i $key -o StrictHostKeyChecking=no "$@"\n'
 
 function mkTempFile(prefix, suffix) {
     var randomStr = crypto.randomBytes(4).toString('hex')

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mocha": "^2.2.5"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha -R tap"
+    "test": "grunt test"
   },
   "optionalDependencies": {},
   "engines": {

--- a/package.json
+++ b/package.json
@@ -15,11 +15,17 @@
   },
   "main": "index.js",
   "dependencies": {
+    "cross-spawn": "^0.4.1",
     "step": "~0.0.5"
   },
   "devDependencies": {
-    "mocha": "~1.3.0",
-    "chai": "~1.1.1"
+    "chai": "~1.1.1",
+    "grunt": "^0.4.5",
+    "grunt-contrib-jshint": "^0.11.2",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-mocha-test": "^0.12.7",
+    "matchdep": "^0.3.0",
+    "mocha": "^2.2.5"
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha -R tap"

--- a/test/test.js
+++ b/test/test.js
@@ -87,14 +87,20 @@ describe('gitane', function() {
         var stats = fs.statSync(file)
 
         // Note we must convert to octal ourselves.
-        expect(stats.mode.toString(8)).to.eql('100755')
+	if (process.platform == 'win32') {
+		expect(stats.mode.toString(8)).to.eql('100666');
+	} else {
+		expect(stats.mode.toString(8)).to.eql('100755')
+	}
 
         fs.unlinkSync(file)
 
         var stats = fs.statSync(keyfile)
-
-        // Note we must convert to octal ourselves.
-        expect(stats.mode.toString(8)).to.eql('100600')
+	if (process.platform == 'win32') {
+		expect(stats.mode.toString(8)).to.eql('100666');
+	} else {
+		expect(stats.mode.toString(8)).to.eql('100755')
+	}
 
         fs.unlinkSync(keyfile)
 
@@ -113,16 +119,20 @@ describe('gitane', function() {
         var stats = fs.statSync(file)
 
         // Note we must convert to octal ourselves.
-        expect(stats.mode.toString(8)).to.eql('100755')
+	if (process.platform == 'win32') {
+		expect(stats.mode.toString(8)).to.eql('100666');
+	} else {
+		expect(stats.mode.toString(8)).to.eql('100755')
+	}
 
         fs.unlinkSync(file)
 
         var stats = fs.statSync(keyfile)
-
-        // Note we must convert to octal ourselves.
-        expect(stats.mode.toString(8)).to.eql('100744')
-
-        fs.unlinkSync(keyfile)
+	if (process.platform == 'win32') {
+		expect(stats.mode.toString(8)).to.eql('100666');
+	} else {
+		expect(stats.mode.toString(8)).to.eql('100744')
+	}
 
         done()
       })

--- a/test/test.js
+++ b/test/test.js
@@ -46,7 +46,7 @@ describe('gitane', function() {
         expect(file).to.be.a('string')
         expect(file).to.match(/_gitane/)
         var data = fs.readFileSync(file, 'utf8')
-        expect(data).to.match(/exec ssh -i/)
+        expect(data).to.match(/ssh -i/)
 
         var key = fs.readFileSync(keyfile, 'utf8')
         expect(key).to.eql('testkey')
@@ -65,7 +65,7 @@ describe('gitane', function() {
         expect(file).to.eql(filename)
         expect(err).to.be.null
         var data = fs.readFileSync(file, 'utf8')
-        expect(data).to.match(/exec ssh -i/)
+        expect(data).to.match(/ssh -i/)
         var key = fs.readFileSync(keyfile, 'utf8')
         expect(key).to.eql('testkey')
 

--- a/test/test.js
+++ b/test/test.js
@@ -138,21 +138,19 @@ describe('gitane', function() {
 
     it('should support event emitter parameter for real-time updates', function(done) {
       var testkey = 'testkey'
+      var echoMessage = 'hello'
       var gotStdout = false
       function mockEmit(ev, data) {
         if (ev === 'stdout') {
             gotStdout = true
-            expect(fs.realpathSync(data.trim())).to.eql(fs.realpathSync(os.tmpDir()))
+            expect(data.trim()).to.eql(echoMessage)
         }
       }
-      var opts = {emitter: {emit:mockEmit}, baseDir:os.tmpDir(), privKey: testkey, cmd:'env'}
+
+      var opts = { emitter: { emit: mockEmit }, baseDir: os.tmpDir(), privkey: testkey, cmd: 'echo ' + echoMessage}
       gitane.run(opts, function(err, stdout, stderr) {
         expect(err).to.be.null
-console.log('lllllll')
-console.log(stdout.trim())
-console.log(stderr.trim())
-console.log(fs.realpathSync(stdout.trim()))
-        expect(fs.realpathSync(stdout.trim())).to.eql(fs.realpathSync(os.tmpDir()))
+        expect(stdout.trim()).to.eql(echoMessage)
         expect(gotStdout).to.be.true
         done()
       })

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ describe('gitane', function() {
     it('should run the command with correct GIT_SSH environment', function(done) {
       var testkey = 'testkey'
 
-      gitane.run(process.cwd(), testkey, 'env', function(err, stdout, stderr) {
+      gitane.run({baseDir: process.cwd(), detached: false, priKey: testkey, cmd: 'env'}, function(err, stdout, stderr) {
         expect(err).to.be.null
         expect(stdout).to.match(/GIT_SSH=.*_gitane.*\.sh/)
         done()
@@ -20,7 +20,7 @@ describe('gitane', function() {
     it('should run the command in the correct baseDir', function(done) {
       var testkey = 'testkey'
 
-      gitane.run(os.tmpDir(), testkey, 'pwd', function(err, stdout, stderr) {
+      gitane.run({baseDir: os.tmpDir(), detached: true, priKey: testkey, cmd: 'pwd'}, function(err, stdout, stderr) {
         expect(err).to.be.null
         expect(fs.realpathSync(stdout.trim())).to.eql(fs.realpathSync(os.tmpDir()))
         done()
@@ -50,6 +50,7 @@ describe('gitane', function() {
 
         var key = fs.readFileSync(keyfile, 'utf8')
         expect(key).to.eql('testkey')
+
         fs.unlinkSync(file)
         fs.unlinkSync(keyfile)
 
@@ -85,23 +86,20 @@ describe('gitane', function() {
         expect(err).to.be.null
 
         var stats = fs.statSync(file)
-
-        // Note we must convert to octal ourselves.
-	if (process.platform == 'win32') {
-		expect(stats.mode.toString(8)).to.eql('100666');
-	} else {
-		expect(stats.mode.toString(8)).to.eql('100755')
-	}
-
-        fs.unlinkSync(file)
+      	if (process.platform == 'win32') {
+      		expect(stats.mode.toString(8)).to.eql('100666');
+      	} else {
+      		expect(stats.mode.toString(8)).to.eql('100755')
+      	}
 
         var stats = fs.statSync(keyfile)
-	if (process.platform == 'win32') {
-		expect(stats.mode.toString(8)).to.eql('100666');
-	} else {
-		expect(stats.mode.toString(8)).to.eql('100755')
-	}
+      	if (process.platform == 'win32') {
+      		expect(stats.mode.toString(8)).to.eql('100666');
+      	} else {
+      		expect(stats.mode.toString(8)).to.eql('100755')
+      	}
 
+        fs.unlinkSync(file)
         fs.unlinkSync(keyfile)
 
         done()
@@ -117,22 +115,21 @@ describe('gitane', function() {
         expect(err).to.be.null
 
         var stats = fs.statSync(file)
-
-        // Note we must convert to octal ourselves.
-	if (process.platform == 'win32') {
-		expect(stats.mode.toString(8)).to.eql('100666');
-	} else {
-		expect(stats.mode.toString(8)).to.eql('100755')
-	}
-
-        fs.unlinkSync(file)
+      	if (process.platform == 'win32') {
+      		expect(stats.mode.toString(8)).to.eql('100666');
+      	} else {
+      		expect(stats.mode.toString(8)).to.eql('100755')
+      	}
 
         var stats = fs.statSync(keyfile)
-	if (process.platform == 'win32') {
-		expect(stats.mode.toString(8)).to.eql('100666');
-	} else {
-		expect(stats.mode.toString(8)).to.eql('100744')
-	}
+      	if (process.platform == 'win32') {
+      		expect(stats.mode.toString(8)).to.eql('100666');
+      	} else {
+      		expect(stats.mode.toString(8)).to.eql('100744')
+      	}
+
+        fs.unlinkSync(file)
+        fs.unlinkSync(keyfile)
 
         done()
       })
@@ -143,15 +140,16 @@ describe('gitane', function() {
       var testkey = 'testkey'
       var gotStdout = false
       function mockEmit(ev, data) {
-        console.log("emitter")
         if (ev === 'stdout') {
             gotStdout = true
             expect(fs.realpathSync(data.trim())).to.eql(fs.realpathSync(os.tmpDir()))
         }
       }
-      var opts = {emitter: {emit:mockEmit}, baseDir:os.tmpDir(), privKey: testkey, cmd:'pwd'}
+      var opts = {emitter: {emit:mockEmit}, baseDir:os.tmpDir(), privKey: testkey, cmd:'whoami'}
       gitane.run(opts, function(err, stdout, stderr) {
         expect(err).to.be.null
+        console.log(stdout.trim())
+        console.log(stderr.trim())
         expect(fs.realpathSync(stdout.trim())).to.eql(fs.realpathSync(os.tmpDir()))
         expect(gotStdout).to.be.true
         done()

--- a/test/test.js
+++ b/test/test.js
@@ -96,7 +96,7 @@ describe('gitane', function() {
       	if (process.platform == 'win32') {
       		expect(stats.mode.toString(8)).to.eql('100666');
       	} else {
-      		expect(stats.mode.toString(8)).to.eql('100755')
+      		expect(stats.mode.toString(8)).to.eql('100600')
       	}
 
         fs.unlinkSync(file)

--- a/test/test.js
+++ b/test/test.js
@@ -10,7 +10,7 @@ describe('gitane', function() {
     it('should run the command with correct GIT_SSH environment', function(done) {
       var testkey = 'testkey'
 
-      gitane.run({baseDir: process.cwd(), detached: false, priKey: testkey, cmd: 'env'}, function(err, stdout, stderr) {
+      gitane.run(process.cwd(), testkey, 'env', function(err, stdout, stderr) {
         expect(err).to.be.null
         expect(stdout).to.match(/GIT_SSH=.*_gitane.*\.sh/)
         done()
@@ -20,7 +20,7 @@ describe('gitane', function() {
     it('should run the command in the correct baseDir', function(done) {
       var testkey = 'testkey'
 
-      gitane.run({baseDir: os.tmpDir(), detached: true, priKey: testkey, cmd: 'pwd'}, function(err, stdout, stderr) {
+      gitane.run(os.tmpDir(), testkey, 'pwd', function(err, stdout, stderr) {
         expect(err).to.be.null
         expect(fs.realpathSync(stdout.trim())).to.eql(fs.realpathSync(os.tmpDir()))
         done()
@@ -145,11 +145,13 @@ describe('gitane', function() {
             expect(fs.realpathSync(data.trim())).to.eql(fs.realpathSync(os.tmpDir()))
         }
       }
-      var opts = {emitter: {emit:mockEmit}, baseDir:os.tmpDir(), privKey: testkey, cmd:'whoami'}
+      var opts = {emitter: {emit:mockEmit}, baseDir:os.tmpDir(), privKey: testkey, cmd:'env'}
       gitane.run(opts, function(err, stdout, stderr) {
         expect(err).to.be.null
-        console.log(stdout.trim())
-        console.log(stderr.trim())
+console.log('lllllll')
+console.log(stdout.trim())
+console.log(stderr.trim())
+console.log(fs.realpathSync(stdout.trim()))
         expect(fs.realpathSync(stdout.trim())).to.eql(fs.realpathSync(os.tmpDir()))
         expect(gotStdout).to.be.true
         done()


### PR DESCRIPTION
Major changes:
* use cross-spawn npm instead of relying on npm's spawn fn
* update tests to use more platform agnostic cmds like 'echo'
* add grunt for running jslint and mocha tests

Known Issues:
* a couple of the unit tests will fail as I haven't yet found an equivalent of "pwd" on Windows. `cd %cd%` doesn't seem to work. 